### PR TITLE
Fix missing import in WebSocket handler

### DIFF
--- a/server/websocket.js
+++ b/server/websocket.js
@@ -1,6 +1,7 @@
 // server/websocket.js
 import WebSocket from 'ws'
-import { validateJWT } from './auth'
+// Import verifyCaseAccess to ensure authorization checks work
+import { validateJWT, verifyCaseAccess } from './auth'
 
 const wss = new WebSocket.Server({ noServer: true })
 


### PR DESCRIPTION
## Summary
- import `verifyCaseAccess` in the WebSocket server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847a54936b88332a565e8d5cecba769