### PR TITLE
Fix websocket handler

### DIFF
--- a/server/middleware/audit.js
+++ b/server/middleware/audit.js
@@ -1,11 +1,11 @@
 // server/middleware/audit.js
 const db = require('../db'); // Adjust the path as needed to your db module
 
-const logAction = (userId, action, record) => {
-    db.query(
-      `INSERT INTO audit_log (user_id, action_type, affected_record)
-       VALUES ($1, $2, $3)`,
-      [userId, action, JSON.stringify(record)]
-    );
-  };
+export const logAction = (userId, action, record) => {
+  db.query(
+    `INSERT INTO audit_log (user_id, action_type, affected_record)
+     VALUES ($1, $2, $3)`,
+    [userId, action, JSON.stringify(record)]
+  );
+};
   

--- a/server/websocket.js
+++ b/server/websocket.js
@@ -1,6 +1,6 @@
 // server/websocket.js
 import WebSocket from 'ws'
-import { validateJWT } from './auth'
+import { validateJWT, verifyCaseAccess } from './auth'
 
 const wss = new WebSocket.Server({ noServer: true })
 
@@ -27,8 +27,7 @@ wss.on('close', () => {
 })
 wss.on('error', (error) => {
   console.error('WebSocket error:', error)
-}
-)
+})
 export default wss
 
 


### PR DESCRIPTION
## Summary
- export `logAction` from audit middleware
- import missing helper and clean up error handler in websocket module

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6847a60ddec08332b40c8425e4afc328